### PR TITLE
Implement Viabill Purchase API

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,4 +3,9 @@ require:
 
 AllCops:
   NewCops: disable
-  
+
+RSpec/MultipleExpectations:
+  Max: 5
+
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false

--- a/app/models/solidus_viabill/gateway.rb
+++ b/app/models/solidus_viabill/gateway.rb
@@ -54,7 +54,15 @@ module SolidusViabill
 
     def void(*args); end
 
-    def purchase(*args); end
+    def purchase(float_amount, payment_source, gateway_options)
+      capture(float_amount, payment_source.order_number, gateway_options)
+      ActiveMerchant::Billing::Response.new(
+        true,
+        'Transaction approved and captured',
+        payment_source.attributes,
+        authorization: payment_source.order_number
+      )
+    end
 
     def generate_signature(*args, join_character)
       base_string = args.join(join_character)

--- a/spec/helpers/solidus_viabill/api/checkout_helper_spec.rb
+++ b/spec/helpers/solidus_viabill/api/checkout_helper_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe SolidusViabill::Api::CheckoutHelper, type: :helper do
   let(:order) { create(:order, bill_address: spree_address, ship_address: spree_address, user: spree_user) }
   let(:payment_method) { create(:viabill_payment_method) }
 
-  # rubocop:disable RSpec/MultipleMemoizedHelpers
   describe '#build_checkout_request_body' do
     subject(:checkout_body) { build_checkout_request_body(order, payment_method.id) }
 
@@ -131,5 +130,4 @@ RSpec.describe SolidusViabill::Api::CheckoutHelper, type: :helper do
       }.to raise_error RuntimeError
     end
   end
-  # rubocop:enable RSpec/MultipleMemoizedHelpers
 end


### PR DESCRIPTION
This commit implements the Purchase API for Viabill
The purchase API calls the capture method from the Gateway Class in SolidusViabill to create and capture the amount from the transaction.
This method is invoked only when AutoCapture is set to true for the Payment Method.