### PR TITLE
Change #callback from GET to POST

### DIFF
--- a/app/controllers/solidus_viabill/api/checkout_controller.rb
+++ b/app/controllers/solidus_viabill/api/checkout_controller.rb
@@ -29,7 +29,9 @@ module SolidusViabill
         redirect_to redirect_url
       end
 
-      def callback; end
+      def callback
+        render json: {}, status: :ok
+      end
 
       private
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,6 @@
 
 Spree::Core::Engine.routes.draw do
   get '/api/checkout_authorize', to: '/solidus_viabill/api/checkout#authorize', as: 'viabill_checkout_authorize'
-  get '/api/checkout_callback', to: '/solidus_viabill/api/checkout#callback', as: 'viabill_checkout_callback'
+  post '/api/checkout_callback', to: '/solidus_viabill/api/checkout#callback', as: 'viabill_checkout_callback'
   get '/api/checkout_success', to: '/solidus_viabill/api/checkout#success', as: 'viabill_checkout_success'
 end

--- a/spec/requests/solidus_viabill/api/checkout_spec.rb
+++ b/spec/requests/solidus_viabill/api/checkout_spec.rb
@@ -127,4 +127,12 @@ RSpec.describe "SolidusViabill::Api::Checkouts", type: :request do
       end
     end
   end
+
+  describe '#callback' do
+    before { post viabill_checkout_callback_path }
+
+    it 'has http status 200' do
+      expect(response.status).to eq(200)
+    end
+  end
 end


### PR DESCRIPTION
ViaBill's documentation isn't very clear on the callback function, but we expect the error comes from the fact that we've defined it as a GET endpoint rather than a POST one.
Changed to match that