### PR TITLE
Fix CSRF and Skip #load_token Before Action

### DIFF
--- a/app/controllers/solidus_viabill/api/checkout_controller.rb
+++ b/app/controllers/solidus_viabill/api/checkout_controller.rb
@@ -6,7 +6,8 @@ module SolidusViabill
       include Spree::Core::ControllerHelpers::Order
       include SolidusViabill::Api::CheckoutHelper
 
-      before_action :load_order
+      skip_before_action :verify_authenticity_token
+      before_action :load_order, only: %i[authorize success]
 
       def authorize
         payment_method_id = params[:payment_method_id]


### PR DESCRIPTION
After some more testing we found out that sending a POST request to `/api/checkout_callback` raises a CSRF error.

We added the fix for that and also skipped loading an order for the callback action