### PR TITLE
Fix #build_checkout_request_body

### DIFF
--- a/app/helpers/solidus_viabill/api/checkout_helper.rb
+++ b/app/helpers/solidus_viabill/api/checkout_helper.rb
@@ -33,13 +33,13 @@ module SolidusViabill
           }
         }
         request_body[:sha256check] = gateway.generate_signature(
-          gateway.api_key,
+          request_body[:apikey],
           request_body[:amount],
           request_body[:currency],
           request_body[:transaction],
           request_body[:order_number],
-          gateway.success_url,
-          gateway.cancel_url,
+          request_body[:success_url],
+          request_body[:cancel_url],
           gateway.secret_key
         )
         request_body

--- a/lib/solidus_viabill/testing_support/factories.rb
+++ b/lib/solidus_viabill/testing_support/factories.rb
@@ -12,8 +12,13 @@ FactoryBot.define do
   end
 
   factory :viabill_payment_method, class: SolidusViabill::ViabillPaymentMethod do
-    name { 'Viabill' }
-    available_to_admin { true }
-    available_to_users { true }
+    name                           { 'Viabill' }
+    available_to_admin             { true }
+    available_to_users             { true }
+    preferred_viabill_api_key      { 'apikey' }
+    preferred_viabill_success_url  { 'https://example.com/api/checkout_success' }
+    preferred_viabill_cancel_url   { 'https://example.com/checkout/payment' }
+    preferred_viabill_callback_url { 'https://example.com/api/checkout_callback' }
+    preferred_viabill_test_env     { true }
   end
 end

--- a/spec/helpers/solidus_viabill/api/checkout_helper_spec.rb
+++ b/spec/helpers/solidus_viabill/api/checkout_helper_spec.rb
@@ -7,37 +7,68 @@ RSpec.describe SolidusViabill::Api::CheckoutHelper, type: :helper do
   let(:payment_method) { create(:viabill_payment_method) }
 
   describe '#build_checkout_request_body' do
-    context 'when frontend is true' do
-      subject(:checkout_body) { build_checkout_request_body(order, payment_method.id, true) }
+    subject(:checkout_body) { build_checkout_request_body(order, payment_method.id, frontend) }
 
-      let(:key_list) {
-        [
-          :protocol,
-          :transaction,
-          :amount,
-          :currency,
-          :test,
-          :md5check,
-          :sha256check,
-          :apikey,
-          :order_number,
-          :success_url,
-          :cancel_url,
-          :callback_url,
-          :customParams
-        ]
+    let(:result) do
+      {
+        amount: "0.0",
+        apikey: "apikey",
+        callback_url: "https://example.com/api/checkout_callback",
+        cancel_url: "https://example.com/checkout/payment",
+        currency: "USD",
+        customParams: {
+          address: "A Different Road, Northwest",
+          city: "Herndon",
+          country: "United States",
+          email: order.email,
+          fullName: "John Von Doe",
+          phoneNumber: "555-555-0199",
+          postalCode: order.bill_address.zipcode
+        },
+        md5check: "",
+        order_number: order.number,
+        protocol: "3.1",
+        sha256check: "sha256check",
+        success_url: "https://example.com/api/checkout_success?payment_method_id=#{payment_method.id}&frontend=#{frontend}&order_number=#{order.number}",
+        test: "true",
+        transaction: order.number,
       }
-      let(:custom_param_key_list) {
-        [
-          :email,
-          :phoneNumber,
-          :fullName,
-          :address,
-          :city,
-          :postalCode,
-          :country
-        ]
-      }
+    end
+    let(:key_list) {
+      [
+        :protocol,
+        :transaction,
+        :amount,
+        :currency,
+        :test,
+        :md5check,
+        :sha256check,
+        :apikey,
+        :order_number,
+        :success_url,
+        :cancel_url,
+        :callback_url,
+        :customParams
+      ]
+    }
+    let(:custom_param_key_list) {
+      [
+        :email,
+        :phoneNumber,
+        :fullName,
+        :address,
+        :city,
+        :postalCode,
+        :country
+      ]
+    }
+
+    # rubocop:disable RSpec/AnyInstance
+    before { allow_any_instance_of(SolidusViabill::Gateway).to receive(:generate_signature).and_return('sha256check') }
+    # rubocop:enable RSpec/AnyInstance
+
+    context 'when frontend is true' do
+      let(:frontend) { true }
 
       it 'has all keys' do
         expect(checkout_body.keys).to eq key_list
@@ -45,40 +76,15 @@ RSpec.describe SolidusViabill::Api::CheckoutHelper, type: :helper do
 
       it 'has all keys in customParams' do
         expect(checkout_body[:customParams].keys).to eq custom_param_key_list
+      end
+
+      it 'builds a request body' do
+        expect(checkout_body).to eq(result)
       end
     end
 
     context 'when frontend is false' do
-      subject(:checkout_body) { build_checkout_request_body(order, payment_method.id, false) }
-
-      let(:key_list) {
-        [
-          :protocol,
-          :transaction,
-          :amount,
-          :currency,
-          :test,
-          :md5check,
-          :sha256check,
-          :apikey,
-          :order_number,
-          :success_url,
-          :cancel_url,
-          :callback_url,
-          :customParams
-        ]
-      }
-      let(:custom_param_key_list) {
-        [
-          :email,
-          :phoneNumber,
-          :fullName,
-          :address,
-          :city,
-          :postalCode,
-          :country
-        ]
-      }
+      let(:frontend) { false }
 
       it 'has all keys' do
         expect(checkout_body.keys).to eq key_list
@@ -86,6 +92,10 @@ RSpec.describe SolidusViabill::Api::CheckoutHelper, type: :helper do
 
       it 'has all keys in customParams' do
         expect(checkout_body[:customParams].keys).to eq custom_param_key_list
+      end
+
+      it 'builds a request body' do
+        expect(checkout_body).to eq(result)
       end
     end
   end


### PR DESCRIPTION
In commit https://github.com/nebulab/solidus_viabill/pull/15/commits/7e1440811db87ad527315633791f8901f19b4a33 we changed request_body[:success_url] for gateway.success_url
which generates an error because the former returns a url with params, while the latter without.
With this commit we are reverting that change and aligning the rest of the parameters to match
in format with this one.
